### PR TITLE
Remove default methods on Column

### DIFF
--- a/src/Tables/Columns/IdentityColumn.php
+++ b/src/Tables/Columns/IdentityColumn.php
@@ -30,15 +30,7 @@ class IdentityColumn extends TextColumn
 
     public static function make(?string $name = null): static
     {
-        $column = parent::make($name);
-
-        $column
-            ->label('ID')
-            ->sortable()
-            ->searchable()
-            ->toggleable(isToggledHiddenByDefault: false);
-
-        return $column;
+        return parent::make($name);
     }
 
     /**


### PR DESCRIPTION
I'm not sure why `$column` has these default methods, but in some contexts it makes appears an empty column manager.
Even when I add `->toggleable(false)`, then some filters are showing.

Since it looks not useful to have these defaults and users can still add them if they want, I propose to just return parent defaults.